### PR TITLE
Compatibility and reverse order of pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,11 @@ I'm not great at PHP (part of the reason I use Pico in the first place). If you 
 
 # Installation
 1. Copy to RssMaker.php to the plugins folder.
-2. Add the following line to your config.php:
-
-    $config['RssMaker.enabled'] = true;
-    
+2. Add the following line to your config.yml: `RssMaker.enabled = true`
 3. Your feed URL will be example.com/feed. Navigate here to make sure it works.
 
 # Compatibility
 I've not extensively tested the plugin, but it's worked fine on the following installations (testament to the hard work the Pico team put into backwards compatibility in Pico 2).
 * 1.0.4
 * 2.0.2
+* 2.0.4

--- a/RssMaker.php
+++ b/RssMaker.php
@@ -3,9 +3,6 @@
 /**
  * RssMaker - basic RSS feed generator for Pico
  *
- * You're a plugin developer? This template may be helpful :-)
- * Simply remove the events you don't need and add your own logic.
- *
  * @author  Matt Barnard
  * @link    https://github.com/picocms/Pico/blob/master/plugins/DummyPlugin.php
  * @license http://opensource.org/licenses/MIT The MIT License
@@ -91,9 +88,12 @@ final class RssMaker extends AbstractPicoPlugin
             $rss .= $this->feedTitle;
             $rss .= '</title>';
             $rss .= '<atom:link href="{{ base_url }}/feed" rel="self" type="application/rss+xml" />';
+            
+            //Reverse order like in a blog
+            $reverse_pages = array_reverse($pages);
 
             //Page loop
-            foreach ($pages as $page) {
+            foreach ($reverse_pages as $page) {
                 if (!empty($page['date'])) {
                     $rss .= '<item>';
                     $rss .= '<title>';


### PR DESCRIPTION
Hello, great plugin, for my website I was looking for something exactly like it, too ;)
I've added info in readme that plugin works with Pico 2.0.4, changed config.php to config.yml line and made reverse order of pages. The change in plugin's PHP will return pages with date in order like in a blog, from the newest to the oldest. I've thought that maybe some people also want it so decided to do a request. Let me know what do you think about it :smiley: